### PR TITLE
Change max from parameter to instance variable

### DIFF
--- a/src/sorts/SmartBogoSort.java
+++ b/src/sorts/SmartBogoSort.java
@@ -27,7 +27,7 @@ SOFTWARE.
 
 final public class SmartBogoSort extends BogoSorting {
 
-	private int length;
+	private int max;
 
     public SmartBogoSort(Delays delayOps, Highlights markOps, Reads readOps, Writes writeOps) {
         super(delayOps, markOps, readOps, writeOps);
@@ -45,24 +45,23 @@ final public class SmartBogoSort extends BogoSorting {
 
     @Override
     public void runSort(int[] array, int currentLen, int bucketCount) {
-    	length = currentLen;
-        permutationSort(array, 0, currentLen-1);
+    	max = currentLen - 1;
+        permutationSort(array, 0);
     }
 
-    private boolean permutationSort(int[] array, int min, int max)
+    private boolean permutationSort(int[] array, int min)
     {
-    	if(max != length-1) throw new RuntimeException();
         boolean sorted = false;
         int i;
         for(i = max; i > min; i--)
         {
             if(max > min+1)
             {
-                sorted = permutationSort(array, min+1, max); //permutation = recurrence relation
+                sorted = permutationSort(array, min+1); //permutation = recurrence relation
             }
             if(sorted || this.bogoIsSorted(array, max+1))
             {
-                return sorted;
+                return true;
             }
 			if((max+1-min)%2 == 0)
 			{
@@ -73,7 +72,7 @@ final public class SmartBogoSort extends BogoSorting {
 		}
         if(max > min+1)
         {
-            return permutationSort(array, min+1, max); //permutation = recurrence relation
+            return permutationSort(array, min+1); //permutation = recurrence relation
         }
         return false;
     }


### PR DESCRIPTION
I'm don't think a check at the top on `max` is necessary to enforce it's consistency, but seeing how blatantly unchanging it was I realized that it would be better as an instance variable than a parameter being carried by the function. If you believe it's necessary to have safety check it that's fine, go ahead and add it, but to me it just seemed like an unnecessary extra operation that gets carried at factorial timescale.
I also noticed that in the sort checking portion when `sorted` is false and a call is made to `this.bogoIsSorted`, if it returned true the false `sorted` would still be returned which means the sort would be rechecked all the way up the function stack. I've changed the return to true to resolve this, as returning there means it is sorted.
Thanks for taking a look at this!